### PR TITLE
Show search magnify optionally, show clear on page load

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -5,19 +5,29 @@
     <title>jQuery SearchInput Demo</title>
 
     <link rel="stylesheet" type="text/css"
-          href="dist/styles/jquery.searchinput.min.css"/>
+          href="src/styles/jquery.searchinput.css"/>
 
-    <script src="//code.jquery.com/jquery-latest.js"></script>
-    <script src="dist/jquery.searchinput.min.js"></script>
+    <script src="http://code.jquery.com/jquery-latest.js"></script>
+    <script src="src/jquery.searchinput.js"></script>
+    <style>
+        /* disable clear button in Internet Explorer 10 'x' */
+        input[type=text]::-ms-clear {display: none;}
+    </style>
 </head>
 <body>
+
 <div style="margin:4px;padding:4px;">
-    <input type="text" id="input" placeholder="Search" />
+    <input type="text" id="input" value="" placeholder="Search" /> <br>
+    <input type="text" id="input1" value="default text" placeholder="Search" /> <br>
+
+    <input type="text" id="input2" value="" /> <br>
+    <input type="text" id="input3" value="default text" /> <br>
 </div>
 
 <script>
     $(function () {
-        $('#input').searchInput();
+        $('#input, #input1').searchInput({'magnify' : true});
+        $('#input2, #input3').searchInput({'magnify' : false});
     });
 </script>
 </body>

--- a/src/jquery.searchinput.js
+++ b/src/jquery.searchinput.js
@@ -4,18 +4,17 @@
 
 (function ($) {
 
-	// Mewsoft addition
-	$.fn.clearInput = function(options) {
+	$.fn.searchInput = function(options) {
 
 		var settings = $.extend({
 			'magnify' : false,
 		}, options);
+		
+		var clear_icon_class = settings.magnify ? 'searchinput-icon-search' : 'searchinput-icon-empty';
 
         var ICON_WIDTH = 16
             , ICON_HEIGHT = 16
             , ICON_PADDING = 1;
-		
-		var clear_icon_class = settings.magnify ? 'clearinput-icon-search' : 'clearinput-icon-empty';
 
         var prepareIconHolder = function (inputEl) {
             var paddingTop = parseInt(inputEl.css('padding-top'))
@@ -48,7 +47,7 @@
 
         var toggleSearchIcon = function (iconEl, isSearchIcon) {
             iconEl.toggleClass(clear_icon_class, isSearchIcon)
-                .toggleClass('clearinput-icon-clear', !isSearchIcon);
+                .toggleClass('searchinput-icon-clear', !isSearchIcon);
         };
 
         var inputHandler = function (inputEl, iconEl) {
@@ -60,7 +59,7 @@
         };
 
         var iconClickHandler = function (inputEl, iconEl) {
-            if (iconEl.hasClass('clearinput-icon-clear')) {
+            if (iconEl.hasClass('searchinput-icon-clear')) {
                 inputEl.val('').focus();
                 toggleSearchIcon(iconEl, true);
             }
@@ -73,8 +72,8 @@
         return this.filter('input').each(function () {
             var inputEl = $(this);
             var iconEl = $('<i>').addClass(clear_icon_class)
-                .addClass('clearinput-icon-clear')
-                .toggleClass('clearinput-icon-clear', false);
+                .addClass('searchinput-icon-clear')
+                .toggleClass('searchinput-icon-clear', false);
 
             prepareIconHolder(inputEl);
             computeIconOffset(inputEl, iconEl);
@@ -83,13 +82,13 @@
             inputEl.on('input', function () {
                 inputHandler($(this), iconEl);
             });
-			//-------------------------
+
             if ($(this).val().length > 0) {
                 toggleSearchIcon(iconEl, false);
             } else {
                 toggleSearchIcon(iconEl, true);
             }
-			//-------------------------
+
             iconEl.on('click', function () {
                 iconClickHandler(inputEl, $(this));
             });
@@ -97,6 +96,7 @@
             $(window).on('resize', function () {
                 resizeHandler(inputEl, iconEl);
             });
+
 			function nop() { }
 			if (!window.MutationObserver) {
 				window.MutationObserver = function () {
@@ -104,7 +104,7 @@
 					this.disconnect = nop;
 				};
 			}
-			//-------------------------
+
             /*
              * Observer for watching display property change on the input element.
              */

--- a/src/jquery.searchinput.js
+++ b/src/jquery.searchinput.js
@@ -4,10 +4,18 @@
 
 (function ($) {
 
-    $.fn.searchInput = function () {
+	// Mewsoft addition
+	$.fn.clearInput = function(options) {
+
+		var settings = $.extend({
+			'magnify' : false,
+		}, options);
+
         var ICON_WIDTH = 16
             , ICON_HEIGHT = 16
             , ICON_PADDING = 1;
+		
+		var clear_icon_class = settings.magnify ? 'clearinput-icon-search' : 'clearinput-icon-empty';
 
         var prepareIconHolder = function (inputEl) {
             var paddingTop = parseInt(inputEl.css('padding-top'))
@@ -39,8 +47,8 @@
         };
 
         var toggleSearchIcon = function (iconEl, isSearchIcon) {
-            iconEl.toggleClass('searchinput-icon-search', isSearchIcon)
-                .toggleClass('searchinput-icon-clear', !isSearchIcon);
+            iconEl.toggleClass(clear_icon_class, isSearchIcon)
+                .toggleClass('clearinput-icon-clear', !isSearchIcon);
         };
 
         var inputHandler = function (inputEl, iconEl) {
@@ -52,7 +60,7 @@
         };
 
         var iconClickHandler = function (inputEl, iconEl) {
-            if (iconEl.hasClass('searchinput-icon-clear')) {
+            if (iconEl.hasClass('clearinput-icon-clear')) {
                 inputEl.val('').focus();
                 toggleSearchIcon(iconEl, true);
             }
@@ -64,9 +72,9 @@
 
         return this.filter('input').each(function () {
             var inputEl = $(this);
-            var iconEl = $('<i>').addClass('searchinput-icon-search')
-                .addClass('searchinput-icon-clear')
-                .toggleClass('searchinput-icon-clear', false);
+            var iconEl = $('<i>').addClass(clear_icon_class)
+                .addClass('clearinput-icon-clear')
+                .toggleClass('clearinput-icon-clear', false);
 
             prepareIconHolder(inputEl);
             computeIconOffset(inputEl, iconEl);
@@ -75,7 +83,13 @@
             inputEl.on('input', function () {
                 inputHandler($(this), iconEl);
             });
-
+			//-------------------------
+            if ($(this).val().length > 0) {
+                toggleSearchIcon(iconEl, false);
+            } else {
+                toggleSearchIcon(iconEl, true);
+            }
+			//-------------------------
             iconEl.on('click', function () {
                 iconClickHandler(inputEl, $(this));
             });
@@ -83,7 +97,14 @@
             $(window).on('resize', function () {
                 resizeHandler(inputEl, iconEl);
             });
-
+			function nop() { }
+			if (!window.MutationObserver) {
+				window.MutationObserver = function () {
+					this.observe = nop;
+					this.disconnect = nop;
+				};
+			}
+			//-------------------------
             /*
              * Observer for watching display property change on the input element.
              */

--- a/src/styles/jquery.searchinput.css
+++ b/src/styles/jquery.searchinput.css
@@ -14,6 +14,14 @@
     z-index: 2000;
 }
 
+.searchinput-icon-empty {
+    background: url("images/icon-clearinput.png") no-repeat -100 -100; /* hide */
+    position: absolute;
+    width: 16px;
+    height: 16px;
+    z-index: 2000;
+}
+
 .searchinput-icon-clear {
     background: url("images/icon-searchclear.png") no-repeat 0 -16px;
     position: absolute;


### PR DESCRIPTION
In this update:

1)- Fixed clear icon show when page loads and the input field has a text like:

```
   <input type="text" value="default search terms">
```

2)- Fixed MutationObserver error in Internet explorer 10 which does not exist by adding:

```
        function nop() { }
        if (!window.MutationObserver) {
            window.MutationObserver = function () {
                this.observe = nop;
                this.disconnect = nop;
            };
        }
```

3)- Added option settings to show/hide the search magnify image if for example the input field is not used for search, this is good to use the clear button only for regular text fields:

To show the search icon magnify image:

$('.clearable').clearInput({'magnify' : true});

To hide the search icon magnify image:

$('.clearable').clearInput({'magnify' : false});

4)- disable clear button in Internet Explorer 10 'x' by adding css:
    <style>
        /\* disable clear button in Internet Explorer 10 'x' */
        input[type=text]::-ms-clear {display: none;}
    </style>
